### PR TITLE
Display assets on mapping area with scaling

### DIFF
--- a/backend/create_sample_assets.py
+++ b/backend/create_sample_assets.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""
+Standalone script to create sample assets for testing the mapping frontend.
+This script sets up the Django environment and creates sample assets with proper types and positions.
+"""
+
+import os
+import sys
+import django
+
+# Add the project directory to the path and set up Django
+sys.path.append('/workspace/backend')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+django.setup()
+
+from ideas.models import Asset, AssetBackground, Map, AssetInMap
+
+def create_sample_data():
+    print("Creating sample asset data...")
+    
+    # Create or get asset types
+    playground_type, created = AssetBackground.objects.get_or_create(
+        type_name='playground',
+        defaults={
+            'cost': 15000.00,
+            'size': '20×15 m',
+            'carbon_emission': 2.5,
+            'primary_user': 'Children aged 5-12',
+            'usage_patterns': 'High usage during afternoons and weekends',
+            'lighting_noise': 'Good lighting required for evening use',
+            'drainage_maintenance': 'Regular sand replacement and equipment inspection'
+        }
+    )
+    print(f"Playground type: {'created' if created else 'exists'}")
+    
+    dogpark_type, created = AssetBackground.objects.get_or_create(
+        type_name='dogpark',
+        defaults={
+            'cost': 25000.00,
+            'size': '30×20 m',
+            'carbon_emission': 1.8,
+            'primary_user': 'Dog owners and pets',
+            'usage_patterns': 'Morning and evening peak usage',
+            'lighting_noise': 'Minimal noise concerns, basic lighting',
+            'drainage_maintenance': 'Regular waste management and grass maintenance'
+        }
+    )
+    print(f"Dog park type: {'created' if created else 'exists'}")
+    
+    restroom_type, created = AssetBackground.objects.get_or_create(
+        type_name='restroom',
+        defaults={
+            'cost': 45000.00,
+            'size': '6×4 m',
+            'carbon_emission': 3.2,
+            'primary_user': 'General public',
+            'usage_patterns': 'Consistent usage throughout the day',
+            'lighting_noise': 'Good lighting and ventilation required',
+            'drainage_maintenance': 'Daily cleaning and regular plumbing maintenance'
+        }
+    )
+    print(f"Restroom type: {'created' if created else 'exists'}")
+    
+    baseball_type, created = AssetBackground.objects.get_or_create(
+        type_name='baseball',
+        defaults={
+            'cost': 75000.00,
+            'size': '90×45 m',
+            'carbon_emission': 5.5,
+            'primary_user': 'Baseball teams and sports enthusiasts',
+            'usage_patterns': 'Seasonal usage, peak in spring/summer',
+            'lighting_noise': 'Stadium lighting for evening games',
+            'drainage_maintenance': 'Field grading and irrigation system maintenance'
+        }
+    )
+    print(f"Baseball type: {'created' if created else 'exists'}")
+    
+    # Create or get the default map
+    default_map, created = Map.objects.get_or_create(
+        name="tijuana_map",
+        defaults={
+            'width': 35.0,  # cm from ArUco coordinate system
+            'height': 23.0  # cm from ArUco coordinate system
+        }
+    )
+    print(f"Map: {'created' if created else 'exists'}")
+    
+    # Create sample assets with positions in the ArUco coordinate system (0-35 x, 0-23 y)
+    assets_data = [
+        {
+            'name': 'Central Playground',
+            'type': playground_type,
+            'marker_id': 10,
+            'x_pos': 12.5,  # Roughly center-left
+            'y_pos': 8.0,
+            'in_map': True,
+            'info': {'capacity': 20, 'age_range': '5-12'}
+        },
+        {
+            'name': 'Community Dog Park',
+            'type': dogpark_type,
+            'marker_id': 11,
+            'x_pos': 25.0,  # Right side
+            'y_pos': 15.0,
+            'in_map': True,
+            'info': {'fenced': True, 'water_fountain': True}
+        },
+        {
+            'name': 'Main Restrooms',
+            'type': restroom_type,
+            'marker_id': 12,
+            'x_pos': 8.0,   # Left side
+            'y_pos': 18.0,
+            'in_map': True,
+            'info': {'accessible': True, 'family_room': True}
+        },
+        {
+            'name': 'Baseball Diamond',
+            'type': baseball_type,
+            'marker_id': 13,
+            'x_pos': 20.0,  # Center-right
+            'y_pos': 5.0,
+            'in_map': True,
+            'info': {'lights': True, 'scoreboard': True}
+        },
+        {
+            'name': 'East Restrooms',
+            'type': restroom_type,
+            'marker_id': 14,
+            'x_pos': 30.0,  # Far right
+            'y_pos': 12.0,
+            'in_map': True,
+            'info': {'accessible': False, 'maintenance_shed': True}
+        }
+    ]
+    
+    created_assets = []
+    for asset_data in assets_data:
+        asset, created = Asset.objects.get_or_create(
+            name=asset_data['name'],
+            marker_id=asset_data['marker_id'],
+            defaults=asset_data
+        )
+        created_assets.append(asset)
+        print(f"Asset '{asset.name}': {'created' if created else 'exists'} at ({asset.x_pos}, {asset.y_pos})")
+    
+    # Add assets to the map
+    asset_in_map, created = AssetInMap.objects.get_or_create(
+        map=default_map,
+    )
+    if created:
+        asset_in_map.assets.set(created_assets)
+        print(f"Added {len(created_assets)} assets to map")
+    else:
+        print("AssetInMap already exists")
+    
+    print(f"\nCreated sample data:")
+    print(f"- {AssetBackground.objects.count()} asset types")
+    print(f"- {Asset.objects.count()} total assets")
+    print(f"- {Asset.objects.filter(in_map=True).count()} assets marked as in_map")
+    print(f"- {Map.objects.count()} map(s)")
+    
+    print("\nAssets in map:")
+    for asset in Asset.objects.filter(in_map=True):
+        print(f"  - {asset.name} ({asset.type.type_name}) at ({asset.x_pos}, {asset.y_pos})")
+
+if __name__ == '__main__':
+    create_sample_data()

--- a/backend/ideas/urls.py
+++ b/backend/ideas/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter    
-from .views import updateCoordinates
+from .views import updateCoordinates, getAssets
 
 # router = DefaultRouter()
 # router.register(r'ideas', IdeaViewSet)
 
 urlpatterns = [
     # path('', include(router.urls)),
-
+    path('assets/', getAssets, name='get-assets'),
     path('update-coordinates/', updateCoordinates, name='update-coordinates'),
 ] 

--- a/backend/ideas/views.py
+++ b/backend/ideas/views.py
@@ -16,6 +16,27 @@ from .serializers import *
 #     queryset = Idea.objects.all()
 #     serializer_class = IdeaSerializer 
 
+@csrf_exempt
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def getAssets(request):
+    """Get all assets with their positions and type information for the mapping frontend"""
+    if request.method == 'GET':
+        assets = Asset.objects.select_related('type').all()
+        data = []
+        for asset in assets:
+            asset_data = {
+                'id': asset.id,
+                'name': asset.name,
+                'type': asset.type.type_name,
+                'marker_id': asset.marker_id,
+                'x_pos': asset.x_pos,
+                'y_pos': asset.y_pos,
+                'in_map': asset.in_map,
+                'info': asset.info or {}
+            }
+            data.append(asset_data)
+        return Response(data, status=status.HTTP_200_OK)
 
 @csrf_exempt
 @api_view(['POST','GET'])

--- a/frontend/src/components/mapping.tsx
+++ b/frontend/src/components/mapping.tsx
@@ -1,108 +1,56 @@
 "use client"
 
-/*
-import React from 'react';
-import {Box} from '@mui/material';
-
-const mockAssets = [
-    {
-      id: 'playground', 
-      x: 100, 
-      y: 150,
-      width: 80,
-      height: 40,
-      color: '#FFD700'
-    },
-    {
-      id: 'dogpark', 
-      x: 300, 
-      y: 200,
-      width: 100,
-      height: 100,
-      color: 'green'
-    },
-    {
-      id: 'restroom', 
-      x: 200, 
-      y: 80,
-      width: 55,
-      height: 30,
-      color: '#ADD8E6'  
-    },
-];
-
-const Mapping = () => {
-    return (
-        <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        aspectRatio: '4/3',
-        height: 510,
-        backgroundImage: 'url(/map.png)',
-        backgroundSize: 'cover',
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: 'center',
-        border: '2px solid black',
-        margin: '0 auto',
-        marginTop: 20,
-      }}
-    >
-      {mockAssets.map((asset) => (
-        <div
-          key={asset.id}
-          style={{
-            position: 'absolute',
-            top: asset.y,
-            left: asset.x,
-            width: asset.width,
-            height: asset.height,
-            backgroundColor: asset.color,
-            border: '2px solid black',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: 12,
-            textAlign: 'center',
-            color: 'black'
-          }}
-        >
-          {asset.id}
-        </div>
-      ))}
-    </div>
-    )
-}
-/*function Mapping() {
-    return (
-        <div>
-            <h1>Mapping</h1>
-        </div>
-    )
-}
-*/
-
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useLayoutEffect, useRef, useState, useEffect } from "react";
 import { Button } from "@mui/material";
 
-type Asset = { id: string; x: number; y: number; width: number; height: number; color: string };
+type Asset = { 
+  id: number;
+  name: string;
+  type: string;
+  marker_id: number;
+  x_pos: number; 
+  y_pos: number; 
+  in_map: boolean;
+  info: any;
+};
 
-const mockAssets: Asset[] = [
-  { id: "playground", x: 100, y: 150, width: 80,  height: 40,  color: "#FFD700" },
-  { id: "dogpark",    x: 300, y: 200, width: 100, height: 100, color: "green"   },
-  { id: "restroom",   x: 200, y:  80, width: 55,  height: 30,  color: "#ADD8E6" },
-];
+// Asset type to image/color mapping
+const ASSET_TYPE_CONFIG = {
+  playground: { 
+    image: '/asset-images/playground.png',
+    color: '#FFD700',
+    size: { width: 60, height: 40 }
+  },
+  dogpark: { 
+    image: '/asset-images/dogpark.png',
+    color: 'green',
+    size: { width: 80, height: 60 }
+  },
+  restroom: { 
+    image: '/asset-images/restroom.png',
+    color: '#ADD8E6',
+    size: { width: 40, height: 30 }
+  },
+  baseball: { 
+    image: '/asset-images/baseball.png',
+    color: '#8B4513',
+    size: { width: 100, height: 70 }
+  },
+  default: {
+    image: null,
+    color: '#999999',
+    size: { width: 50, height: 50 }
+  }
+};
 
 /**
- * Choose the coordinate system you authored against.
- * If you originally placed objects on a 600×450 canvas, keep these as 600/450.
- * If you want to use the map’s native pixels instead, set to 2800/1054
- * and input asset coords/sizes in that space.
+ * ArUco coordinate system: 35cm x 23cm (from OpenCV main.py)
+ * We'll use this as our base coordinate system and scale to the display size
  */
-const BASE_W = 600;
-const BASE_H = 450;
+const ARUCO_MAP_WIDTH = 35;  // cm
+const ARUCO_MAP_HEIGHT = 23; // cm
 
-// Real image pixels (what you told me)
+// Real image pixels (map background image)
 const IMG_W = 2800;
 const IMG_H = 1054;
 const IMG_RATIO = IMG_W / IMG_H; // ≈ 2.6578
@@ -110,6 +58,37 @@ const IMG_RATIO = IMG_W / IMG_H; // ≈ 2.6578
 export default function Mapping() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: 900, h: Math.round(900 / IMG_RATIO) });
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch assets from backend
+  useEffect(() => {
+    const fetchAssets = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch('http://localhost:8000/api/assets/');
+        if (!response.ok) {
+          throw new Error('Failed to fetch assets');
+        }
+        const data = await response.json();
+        // Only show assets that are marked as in_map
+        setAssets(data.filter((asset: Asset) => asset.in_map));
+        setError(null);
+      } catch (err) {
+        console.error('Error fetching assets:', err);
+        setError('Failed to load assets');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAssets();
+    
+    // Refresh assets every 5 seconds to get updated positions
+    const interval = setInterval(fetchAssets, 5000);
+    return () => clearInterval(interval);
+  }, []);
 
   // Track container width and compute height from the true image ratio
   useLayoutEffect(() => {
@@ -128,8 +107,30 @@ export default function Mapping() {
     return () => ro.disconnect();
   }, []);
 
-  const scaleX = size.w / BASE_W;
-  const scaleY = size.h / BASE_H;
+  // Scale from ArUco coordinate system to display coordinates
+  const scaleX = size.w / ARUCO_MAP_WIDTH;
+  const scaleY = size.h / ARUCO_MAP_HEIGHT;
+
+  const getAssetConfig = (type: string) => {
+    const lowerType = type.toLowerCase();
+    return ASSET_TYPE_CONFIG[lowerType as keyof typeof ASSET_TYPE_CONFIG] || ASSET_TYPE_CONFIG.default;
+  };
+
+  if (loading) {
+    return (
+      <div style={{ width: "100%", maxWidth: 1100, margin: "0 auto", padding: "20px", textAlign: "center" }}>
+        Loading assets...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ width: "100%", maxWidth: 1100, margin: "0 auto", padding: "20px", textAlign: "center", color: "red" }}>
+        Error: {error}
+      </div>
+    );
+  }
 
   return (
     <div ref={containerRef} style={{ width: "100%", maxWidth: 1100, margin: "0 auto" }}>
@@ -146,34 +147,65 @@ export default function Mapping() {
           backgroundColor: "#dceac2",      // optional tint
         }}
       >
-        {mockAssets.map((a) => (
-          <div
-            key={a.id}
-            style={{
-              position: "absolute",
-              top: a.y * scaleY,
-              left: a.x * scaleX,
-              width: a.width * scaleX,
-              height: a.height * scaleY,
-              backgroundColor: a.color,
-              border: "2px solid black",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 12,
-              color: "black",
-              boxSizing: "border-box",
-            }}
-          >
-            {a.id}
-          </div>
-        ))}
+        {assets.map((asset) => {
+          const config = getAssetConfig(asset.type);
+          const displayWidth = config.size.width * Math.min(scaleX, scaleY); // Keep aspect ratio
+          const displayHeight = config.size.height * Math.min(scaleX, scaleY);
+          
+          return (
+            <div
+              key={asset.id}
+              style={{
+                position: "absolute",
+                top: asset.y_pos * scaleY - displayHeight / 2, // Center the asset on its position
+                left: asset.x_pos * scaleX - displayWidth / 2,
+                width: displayWidth,
+                height: displayHeight,
+                backgroundColor: config.color,
+                border: "2px solid black",
+                borderRadius: "4px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: Math.max(10, Math.min(14, displayWidth / 8)),
+                color: "white",
+                textShadow: "1px 1px 1px black",
+                fontWeight: "bold",
+                boxSizing: "border-box",
+                backgroundImage: config.image ? `url(${config.image})` : 'none',
+                backgroundSize: "contain",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "center",
+                boxShadow: "0 2px 4px rgba(0,0,0,0.3)"
+              }}
+              title={`${asset.name} (${asset.type}) - Marker ID: ${asset.marker_id}`}
+            >
+              {!config.image && (
+                <span style={{ textAlign: "center", padding: "2px" }}>
+                  {asset.name}
+                </span>
+              )}
+            </div>
+          );
+        })}
         
+        {/* Debug info */}
+        <div style={{ 
+          position: "absolute", 
+          top: 10, 
+          right: 10, 
+          background: "rgba(0,0,0,0.7)", 
+          color: "white", 
+          padding: "5px",
+          borderRadius: "3px",
+          fontSize: "12px"
+        }}>
+          Assets: {assets.length} | Scale: {scaleX.toFixed(2)}x, {scaleY.toFixed(2)}x
+        </div>
       </div>
     </div>
   );
 }
-
 
 
 //export default Mapping;


### PR DESCRIPTION
Display backend assets on the frontend map with accurate scaling and real-time updates.

This PR integrates the frontend mapping component with a new backend API endpoint (`/api/assets/`) to fetch real asset data, replacing the previous mock data. It implements a scaling mechanism to correctly translate ArUco-based coordinates (35cm x 23cm) from the backend to the frontend display, ensuring assets are accurately positioned and sized. A new script, `create_sample_assets.py`, is included to populate the database with test assets for easy verification of the integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b2c51f3-4444-4279-a20a-44e8256a003f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b2c51f3-4444-4279-a20a-44e8256a003f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

